### PR TITLE
remove the github_hosted variable

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,5 @@
 baseurl: "/Handbuch-Jugend-Hackathons"
 
-github_hosted: false
-
 collections:
     chapters_de:
         output: true


### PR DESCRIPTION
This variable was introduced by #20.
It seems it can be removed.

@MagicMarvMan Would you please review?